### PR TITLE
DEVOPS-3339: document README and add Confluence publish workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,21 @@
+name: Publish README to Confluence
+
+on:
+  push:
+    tags:
+      - "[0-9]*"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: elocalorg/github-workflows/.github/actions/publish-to-confluence@master
+        with:
+          parent_page_id: ${{ vars.CONFLUENCE_TERRAFORM_MODULES_PARENT_PAGE_ID }}
+          confluence_base_url: ${{ vars.CONFLUENCE_BASE_URL }}
+          confluence_space_key: ${{ vars.CONFLUENCE_VIKING_SPACE_KEY }}
+          confluence_oidc_client_id: ${{ secrets.CONFLUENCE_OIDC_CLIENT_ID }}
+          confluence_oidc_client_secret: ${{ secrets.CONFLUENCE_OIDC_CLIENT_SECRET }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# terraform-aws-elasticsearch-cloudwatch-sns-alarms
+
+Sets up CloudWatch alarms and SNS notifications for Elasticsearch.
+
+**GitHub:** https://github.com/elocalorg/terraform-aws-elasticsearch-cloudwatch-sns-alarms
+**Terraform Cloud registry:** app.terraform.io/elocal/elasticsearch-cloudwatch-sns-alarms/aws
+**Latest version:** check the latest git tag
+
+## Standards and patterns
+
+Before making changes, read the relevant sub-pages under [Terraform](https://elocal.atlassian.net/wiki/spaces/GP/pages/2702475268/Terraform) in Confluence. Key topics covered there include module design principles, versioning rules, infrastructure patterns (INFRA stacks, single-image, multi-image), and the intermediary entities pattern.
+
+## Confluence publish workflow
+
+The README is auto-published to Confluence on each tag push using the centralized composite action. Do not copy the script locally:
+
+```yaml
+uses: elocalorg/github-workflows/.github/actions/publish-to-confluence@master
+```
+
+Org-level vars/secrets are pre-configured. The only repo-specific input is `parent_page_id` (`vars.CONFLUENCE_TERRAFORM_MODULES_PARENT_PAGE_ID`).
+
+## Do not use the Confluence page for this module as a reference
+
+This module's README will be auto-published to Confluence. That published page is a mirror of the README in this repo — consulting it as a source of truth creates a circular reference. Always use the README in this repo directly.

--- a/README.md
+++ b/README.md
@@ -1,178 +1,211 @@
+> **This page is auto-published to Confluence on each tag push.** Do not edit the Confluence page directly — changes will be overwritten. Make changes in the GitHub repository.
+
 # terraform-aws-elasticsearch-cloudwatch-sns-alarms
 
-[![Build Status](https://travis-ci.com/dubiety/terraform-aws-elasticsearch-cloudwatch-sns-alarms.svg?branch=master)](https://app.travis-ci.com/github/dubiety/terraform-aws-elasticsearch-cloudwatch-sns-alarms)
-[![Latest Release](https://img.shields.io/github/release/dubiety/terraform-aws-elasticsearch-cloudwatch-sns-alarms.svg)](https://github.com/dubiety/terraform-aws-elasticsearch-cloudwatch-sns-alarms/releases)
+**GitHub:** [elocalorg/terraform-aws-elasticsearch-cloudwatch-sns-alarms](https://github.com/elocalorg/terraform-aws-elasticsearch-cloudwatch-sns-alarms)
 
-Terraform module that configures the [recommended Amazon ElasticSearch Alarms](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/cloudwatch-alarms.html) using CloudWatch and sends alerts to an SNS topic.  By default, this module creates an SNS topic, but it can be configured to point to an existing SNS topic (see [example](./examples/use-existing-sns/main.tf))
+## Status
 
-`v1.x` supports terraform `v0.12+` syntax!\
-`v2.0+` supports terraform `v1.0+` syntax!
+> ⚠️ **Deprecated** — superseded by [terraform-aws-opensearch-alarms](https://github.com/elocalorg/terraform-aws-opensearch-alarms). Amazon Elasticsearch Service is end-of-life; AWS migrated all remaining clusters to OpenSearch. No new features will be added; critical fixes only. Existing callers should migrate to the opensearch-alarms module.
 
-This project is inspired by [CloudPosse](https://github.com/cloudposse)\
-It's 100% Open Source and licensed under the [APACHE2](LICENSE).
+## Overview
 
-## Metrics and Alarms
+Creates CloudWatch metric alarms for an Amazon Elasticsearch Service (AWS/ES) domain and routes all alert and recovery notifications to an SNS topic. By default the module creates the SNS topic for you; pass an existing topic ARN if one already exists. The module monitors cluster health, storage, CPU, JVM memory, snapshot failures, shard count, and optionally KMS key health and dedicated-master node metrics.
 
-| Area       | Metric                    | Operator | Threshold | Rationale                                                                                                                              |
-|------------|---------------------------|----------|-----------|----------------------------------------------------------------------------------------------------------------------------------------|
-| Sharding   | ClusterStatus.red         | `>=`     | 1         | At least one primary shard and its replicas are not allocated to a node                                                                |
-| Sharding   | ClusterStatus.yellow      | `>=`     | 1         | At least one replica shard is not allocated to a node                                                                                  |
-| Storage    | FreeStorageSpace          | `<=`     | 20480 MB  | A node in your cluster is down to low storage space.  Note, this alarm uses the aggregate `Minimum` which means this alarm triggers per-node in your cluster.  This logic is based-on the [AWS Recommended Alarms](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/cloudwatch-alarms.html).  It does not however alarm based on an aggregate of free space remaining.  |
-| Storage    | FreeStorageSpaceTotal     | `<=`     | 20480 MB  | The overall disk space free is low.  This alarm uses `Sum` across all your nodes, this can be useful on multi-node clusters.  Disabled by default, to enable this you must set `monitor_free_storage_space_total_too_low` to true, and `free_storage_space_total_threshold`.  Recommended to set the threshold to the number of nodes in your cluster multiplied by the free_storage_space_threshold  |
-| Storage    | ClusterIndexWritesBlocked | `>=`     | 1         | Your cluster is blocking write requests.                                                                                               |
-| Node Count | Nodes                     | `<`      | `x`       | This alarm indicates that at least one node in your cluster has been unreachable for one day                                           |
-| Snapshot   | AutomatedSnapshotFailure  | `>=`     | 1         | An automated snapshot failed. This failure is often the result of a red cluster health status.                                         |
-| CPU        | CPUUtilization            | `>=`     | 80 %      | 100% CPU utilization isn't uncommon, but sustained high usage is problematic. Consider using larger instance types or more instances.  |
-| Memory     | JVMMemoryPressure         | `>=`     | 80 %      | The cluster could encounter out of memory errors if usage increases. Consider scaling vertically.                                      |
-| CPU        | MasterCPUUtilization      | `>=`     | 80 %      | Consider using larger instance types for your dedicated master nodes.                                                                  |
-| Memory     | MasterJVMMemoryPressure   | `>=`     | 80 %      | Consider using larger instance types for your dedicated master nodes.                                                                  |
-| KMS        | KMSKeyError               | `>=`     | 1         | The KMS encryption key that is used to encrypt data at rest in your domain is disabled. Re-enable it to restore normal operations      |
-| Memory     | KMSKeyInaccessible        | `>=`     | 80 %      | The KMS encryption key that is used to encrypt data at rest in your domain has been deleted or has revoked its grants to Amazon ES     |
+## Use this module instead of
 
-For more information please see: [recommended Amazon ElasticSearch Alarms](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/cloudwatch-alarms.html).
+Do not use the following native resources directly. Use this module instead:
 
-## Examples
+* `aws_cloudwatch_metric_alarm` — all CloudWatch alarms for an Elasticsearch domain are managed by this module; defining them separately will conflict with the alarm names this module creates
+* `aws_sns_topic` — managed internally when `create_sns_topic = true` (the default); pass an existing ARN via `sns_topic` and set `create_sns_topic = false` to reuse an existing topic
+* `aws_sns_topic_policy` — managed internally alongside the SNS topic; do not define a separate policy for the topic this module creates
 
-See the [`examples/`](examples/) directory for working examples.
+## What this module enforces
+
+* **Both alarm and OK actions route to SNS** — every alarm sends notifications on threshold breach and on recovery; this cannot be disabled per alarm
+* **Alarm names are scoped to the domain** — all alarm names include the `alarm_name_prefix` and `alarm_name_postfix` variables so multiple domains in the same account do not collide
+* **Per-node storage uses `Minimum` statistic** — `FreeStorageSpace` uses `Minimum` across all nodes, matching AWS recommendations so the alarm fires when any single node is low, not just the average
+* **Most alarms enabled by default** — cluster status red/yellow, free storage, writes blocked, node count, snapshot failure, CPU, and JVM memory are all on by default; KMS and dedicated-master alarms are off by default and must be explicitly enabled
+* **Shard alarm uses `GreaterThanOrEqualToThreshold` on allocated shard count** — triggers when the domain approaches the per-cluster shard limit
+
+## Usage
 
 ```hcl
-resource "aws_elasticsearch_domain" "es" {
-  domain_name           = "example"
-  elasticsearch_version = "7.10"
-
-  cluster_config {
-    instance_type = "r4.large.elasticsearch"
-  }
-
-  snapshot_options {
-    automated_snapshot_start_hour = 23
-  }
-
-  tags = {
-    Domain = "TestDomain"
-  }
-}
-
 module "es_alarms" {
-  source         = "github::https://github.com/dubiety/terraform-aws-elasticsearch-cloudwatch-sns-alarms.git?ref=master"
-  domain_name    = "example"
-  tags = {
-    Domain = "TestDomain"
-  }
+  source  = "app.terraform.io/elocal/elasticsearch-cloudwatch-sns-alarms/aws"
+  version = "~> 1.0"
+
+  domain_name = "my-es-domain"
 }
 ```
 
-You can alternatively have this module not create an SNS in case you have existing ones created elsewhere.
+To reuse an existing SNS topic instead of creating one:
 
 ```hcl
 module "es_alarms" {
-  source           = "github::https://github.com/dubiety/terraform-aws-elasticsearch-cloudwatch-sns-alarms.git?ref=master"
-  domain_name      = "example"
-  sns_topic        = "arn:aws:sns:us-east-1:123456123456:sns-to-slack"   # < Put your full SNS ARN here, if necessary read from var or a resource
+  source  = "app.terraform.io/elocal/elasticsearch-cloudwatch-sns-alarms/aws"
+  version = "~> 1.0"
+
+  domain_name      = "my-es-domain"
+  sns_topic        = "arn:aws:sns:us-east-1:123456789012:my-existing-topic"
   create_sns_topic = false
-  tags = {
-    Domain = "TestDomain"
-  }
 }
 ```
 
+## Configuration guide
+
+### SNS topic
+
+By default the module creates a new SNS topic named with a timestamp suffix. Set `sns_topic_prefix` and `sns_topic_postfix` to control naming. To reuse an existing topic, set `create_sns_topic = false` and pass the full ARN as `sns_topic`.
+
+### Alarm sensitivity (periods and evaluation counts)
+
+Each alarm has a `_period` variable (seconds per datapoint) and a `_periods` variable (number of consecutive datapoints that must breach the threshold before alerting). Increase `_periods` to reduce noise for alarms that fire transiently. CPU and master CPU default to 3 evaluation periods; most others default to 1.
+
+### Shard monitoring
+
+`monitor_allocated_shards_too_high` is enabled by default and alerts when `AllocatedShards` exceeds `available_shards_threshold` (default 5400, tuned for a 6-node cluster at 90% of the 6000-shard limit). Set `available_shards_threshold` to `0.9 * max_shards_per_cluster * node_count` for your cluster size. Also set `max_available_shards` to a non-zero value to enable the upper-bound check.
+
+### Dedicated master node alarms
+
+`monitor_master_cpu_utilization_too_high` and `monitor_master_jvm_memory_pressure_too_high` are disabled by default. Enable them only when the domain has dedicated master nodes configured, otherwise CloudWatch will emit no data for these metrics and the alarm will not behave as expected.
+
+### KMS alarms
+
+`monitor_kms` is disabled by default. Enable it only when the Elasticsearch domain is configured with a KMS customer-managed key for encryption at rest. When enabled, alarms fire if the key is disabled or its grants are revoked.
+
+### Storage thresholds
+
+`free_storage_space_threshold` defaults to 20480 MiB (20 GiB) per node. Set it based on the node's EBS volume size; AWS recommends keeping at least 20% free. `monitor_free_storage_space_total_too_low` is disabled by default; enable it for multi-node clusters and set `free_storage_space_total_threshold` to `free_storage_space_threshold * node_count`.
+
+## What this module does not support
+
+* **OpenSearch domains** — this module targets the `AWS/ES` CloudWatch namespace; for OpenSearch Service domains use [terraform-aws-opensearch-alarms](https://github.com/elocalorg/terraform-aws-opensearch-alarms) instead
+* **Alerting integrations beyond SNS** — routing to PagerDuty, Slack, or other destinations must be wired up at the SNS subscription level outside this module
+* **CloudWatch dashboard creation** — metrics are only alarmed, not visualised; create dashboards separately
+
+## Version history
+
+### 1.0.4 — Fix shard monitor alarm math
+
+_June 2023_
+
+* Corrects the `AllocatedShards` alarm threshold calculation and alarm description
+
+### 1.0.3 — Typo fix
+
+_June 2023_
+
+* Minor description typo fix
+
+### 1.0.2 — Typo fix
+
+_June 2023_
+
+* Minor description typo fix
+
+### 1.0.1 — Add shard monitoring
+
+_June 2023_
+
+* Initial elocal release; extends upstream with `AllocatedShards` CloudWatch alarm (PEV-2723)
+
+---
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
 
 ## Inputs
 
-| Name                                                 | Description | Type | Default | Required |
-|------------------------------------------------------|-------------|:----:|:-------:|:--------:|
-| `domain_name`                                        | The Elasticserach domain name you want to monitor. | string | - | yes |
-| `cluster_type`                                       | The type of cluster, single or multi-node | string | `"single"` | no |
-| `alarm_name_postfix`                                 | Alarm name postfix | string | `""` | no |
-| `alarm_name_prefix`                                  | Alarm name prefix | string | `""` | no |
-| `create_sns_topic`                                   | Will create an SNS topic, if you set this to false you MUST set `sns_topic` to a FULL ARN | bool | `true` | no |
-| `sns_topic`                                          | SNS topic you want to specify. If leave empty, it will use a prefix and a timestamp appended.  If `create_sns_topic` is set to false, this MUST be a FULL ARN | string | `""` | no |
-| `sns_topic_postfix`                                  | SNS topic postfix | string | `""` | no |
-| `sns_topic_prefix`                                   | SNS topic prefix | string | `""` | no |
-| `tags`                                               | Tags to associate with all created resources | map | `{}` | no |
-| `cpu_utilization_threshold`                          | The maximum percentage of CPU utilization | string | `80` | no |
-| `free_storage_space_threshold`                       | The minimum amount of available storage space in MiB. | string | `20480` | no |
-| `jvm_memory_pressure_threshold`                      | The maximum percentage of the Java heap used for all data nodes in the cluster | string | `80` | no |
-| `master_cpu_utilization_threshold`                   | The maximum percentage of CPU utilization of master nodes | string | `""` | no |
-| `master_jvm_memory_pressure_threshold`               | The maximum percentage of the Java heap used for master nodes in the cluster | string | `""` | no |
-| `min_available_nodes`                                | The minimum available (reachable) nodes to have, set to non-zero to enable alarm | string | `0` | no |
-| `monitor_automated_snapshot_failure`                 | Enable monitoring of automated snapshot failure | bool | `true` | no |
-| `monitor_cluster_status_is_red`                      | Enable monitoring of cluster status is in red | bool | `true` | no |
-| `monitor_cluster_status_is_yellow`                   | Enable monitoring of cluster status is in yellow | bool | `true` | no |
-| `monitor_cluster_index_writes_blocked`               | Enable monitoring of cluster index writes being blocked | bool | `true` | no |
-| `monitor_cpu_utilization_too_high`                   | Enable monitoring of CPU utilization is too high | bool | `true` | no |
-| `monitor_free_storage_space_too_low`                 | Enable monitoring of minimum per-node free storage is too low | bool | `true` | no |
-| `monitor_free_storage_space_total_too_low`           | Enable monitoring of cluster total free storage is too low | bool | `false` | no |
-| `monitor_jvm_memory_pressure_too_high`               | Enable monitoring of JVM memory pressure is too high | bool | `true` | no |
-| `monitor_kms`                                        | Enable monitoring of KMS-related metrics, enable if using KMS | bool | `false` | no |
-| `monitor_master_cpu_utilization_too_high`            | Enable monitoring of CPU utilization of master nodes are too high. Only enable this when dedicated master is enabled | bool | `false` | no |
-| `monitor_master_jvm_memory_pressure_too_high`        | Enable monitoring of JVM memory pressure of master nodes are too high. Only enable this wwhen dedicated master is enabled | bool | `false` | no |
-| `monitor_min_available_nodes`                        | Enable monitoring of minimum available nodes | bool | `true` | no |
-| `alarm_automated_snapshot_failure_periods`           | The number of periods to alert that automatic snapshots failed, raise this if desired to make less noisy | number | `1` | no |
-| `alarm_cluster_status_is_red_periods`                | The number of periods to alert that cluster status is red, raise this to be less noisy | number | `1` | no |
-| `alarm_cluster_status_is_yellow_periods`             | The number of periods before triggering the cluster status is yellow, raise this to be less noisy | number | `1` | no |
-| `alarm_cluster_index_writes_blocked_periods`         | The number of periods to alert that cluster index writes are blocked, raise this if desired to make less noisy | number | `1` | no |
-| `alarm_cpu_utilization_too_high_periods`             | The number of periods to alert that CPU usage is too high, raise this if desired to make less noisy | number | `3` | no |
-| `alarm_free_storage_space_too_low_periods`           | The number of periods before triggering the disk space is low, raise this to be less noisy | number | `1` | no |
-| `alarm_free_storage_space_total_too_low_periods`     | The number of periods before triggering the total disk space is low, raise this to be less noisy |  number | `1` | no |
-| `alarm_jvm_memory_pressure_too_high_periods`         | The number of periods which it must be in the alarmed state to alert, raise this if desired to make less noisy | number | `1` | no |
-| `alarm_kms_periods`                                  | The number of periods to alert that kms has failed, raise this if desired to make less noisy | number | `1` | no |
-| `alarm_master_cpu_utilization_too_high_periods`      | The number of periods to alert that masters CPU usage is too high, raise this if desired to make less noisy | number | `3` | no |
-| `alarm_master_jvm_memory_pressure_too_high_periods`  | The number of periods which it must be in the alarmed state to alert, raise this if desired to make less noisy | number | `1` | no |
-| `alarm_min_available_nodes_periods`                  | The number of periods to alert that minimum number of available nodes dropped below a threshold, raise this if desired to make less noisy | number | `1` | no |
-| `alarm_min_available_nodes_period`                   | The period of the minimum available nodes should the statistics be applied in seconds | string | `86400` | no |
-| `alarm_automated_snapshot_failure_period`            | The period of the automated snapshot failure should the statistics be applied in seconds | string | `60` | no |
-| `alarm_cluster_index_writes_blocked_period`          | The period of the cluster index writes being blocked should the statistics be applied in seconds | string | `300` | no |
-| `alarm_cluster_status_is_red_period`                 | The period of the cluster status is in red should the statistics be applied in seconds | string | `60` | no |
-| `alarm_cluster_status_is_yellow_period`              | The period of the cluster status is in yellow should the statistics be applied in seconds | string | `60` | no |
-| `alarm_cpu_utilization_too_high_period`              | The period of the CPU utilization is too high should the statistics be applied in seconds | string | `900` | no |
-| `alarm_free_storage_space_too_low_period`            | The period of the per-node minimum free storage is too low should the statistics be applied in seconds | string | `60` | no |
-| `alarm_free_storage_space_total_too_low_period`      | The period of the cluster total free storage is too low should the statistics be applied in seconds | string | `60` | no |
-| `alarm_jvm_memory_pressure_too_high_period`          | The period of the JVM memory pressure is too high should the statistics be applied in seconds | string | `900` | no |
-| `alarm_kms_period`                                   | The period of the KMS-related metrics should the statistics be applied in seconds | string | `60` | no |
-| `alarm_master_cpu_utilization_too_high_period`       | The period of the CPU utilization of master nodes are too high should the statistics be applied in seconds | string | `900` | no |
-| `alarm_master_jvm_memory_pressure_too_high_period`   | The period of the JVM memory pressure of master nodes are too high should the statistics be applied in seconds | string | `900` | no |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | The Elasticsearch domain name you want to monitor | `string` | n/a | yes |
+| <a name="input_alarm_name_prefix"></a> [alarm\_name\_prefix](#input\_alarm\_name\_prefix) | Alarm name prefix, used in the naming of alarms created | `string` | `""` | no |
+| <a name="input_alarm_name_postfix"></a> [alarm\_name\_postfix](#input\_alarm\_name\_postfix) | Alarm name suffix, used in the naming of alarms created | `string` | `""` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+| <a name="input_create_sns_topic"></a> [create\_sns\_topic](#input\_create\_sns\_topic) | If false, uses `sns_topic` directly instead of creating a new topic | `bool` | `true` | no |
+| <a name="input_sns_topic"></a> [sns\_topic](#input\_sns\_topic) | SNS topic ARN. Required when `create_sns_topic = false`. Ignored when creating a new topic. | `string` | `""` | no |
+| <a name="input_sns_topic_prefix"></a> [sns\_topic\_prefix](#input\_sns\_topic\_prefix) | SNS topic name prefix; only used when creating a new topic | `string` | `""` | no |
+| <a name="input_sns_topic_postfix"></a> [sns\_topic\_postfix](#input\_sns\_topic\_postfix) | SNS topic name suffix; only used when creating a new topic | `string` | `""` | no |
+| <a name="input_monitor_cluster_status_is_red"></a> [monitor\_cluster\_status\_is\_red](#input\_monitor\_cluster\_status\_is\_red) | Enable monitoring of cluster status is in red | `bool` | `true` | no |
+| <a name="input_monitor_cluster_status_is_yellow"></a> [monitor\_cluster\_status\_is\_yellow](#input\_monitor\_cluster\_status\_is\_yellow) | Enable monitoring of cluster status is in yellow | `bool` | `true` | no |
+| <a name="input_monitor_free_storage_space_too_low"></a> [monitor\_free\_storage\_space\_too\_low](#input\_monitor\_free\_storage\_space\_too\_low) | Enable monitoring of per-node free storage space | `bool` | `true` | no |
+| <a name="input_monitor_free_storage_space_total_too_low"></a> [monitor\_free\_storage\_space\_total\_too\_low](#input\_monitor\_free\_storage\_space\_total\_too\_low) | Enable monitoring of cluster total free storage space | `bool` | `false` | no |
+| <a name="input_monitor_cluster_index_writes_blocked"></a> [monitor\_cluster\_index\_writes\_blocked](#input\_monitor\_cluster\_index\_writes\_blocked) | Enable monitoring of cluster index writes being blocked | `bool` | `true` | no |
+| <a name="input_monitor_min_available_nodes"></a> [monitor\_min\_available\_nodes](#input\_monitor\_min\_available\_nodes) | Enable monitoring of minimum available nodes | `bool` | `true` | no |
+| <a name="input_monitor_automated_snapshot_failure"></a> [monitor\_automated\_snapshot\_failure](#input\_monitor\_automated\_snapshot\_failure) | Enable monitoring of automated snapshot failure | `bool` | `true` | no |
+| <a name="input_monitor_cpu_utilization_too_high"></a> [monitor\_cpu\_utilization\_too\_high](#input\_monitor\_cpu\_utilization\_too\_high) | Enable monitoring of CPU utilization | `bool` | `true` | no |
+| <a name="input_monitor_jvm_memory_pressure_too_high"></a> [monitor\_jvm\_memory\_pressure\_too\_high](#input\_monitor\_jvm\_memory\_pressure\_too\_high) | Enable monitoring of JVM memory pressure | `bool` | `true` | no |
+| <a name="input_monitor_kms"></a> [monitor\_kms](#input\_monitor\_kms) | Enable monitoring of KMS-related metrics; only enable when using KMS with Elasticsearch | `bool` | `false` | no |
+| <a name="input_monitor_master_cpu_utilization_too_high"></a> [monitor\_master\_cpu\_utilization\_too\_high](#input\_monitor\_master\_cpu\_utilization\_too\_high) | Enable monitoring of dedicated master node CPU utilization | `bool` | `false` | no |
+| <a name="input_monitor_master_jvm_memory_pressure_too_high"></a> [monitor\_master\_jvm\_memory\_pressure\_too\_high](#input\_monitor\_master\_jvm\_memory\_pressure\_too\_high) | Enable monitoring of dedicated master node JVM memory pressure | `bool` | `false` | no |
+| <a name="input_monitor_allocated_shards_too_high"></a> [monitor\_allocated\_shards\_too\_high](#input\_monitor\_allocated\_shards\_too\_high) | Enable monitoring of per-cluster allocated shard count | `bool` | `true` | no |
+| <a name="input_cpu_utilization_threshold"></a> [cpu\_utilization\_threshold](#input\_cpu\_utilization\_threshold) | Maximum percentage of CPU utilization before alarming | `number` | `80` | no |
+| <a name="input_jvm_memory_pressure_threshold"></a> [jvm\_memory\_pressure\_threshold](#input\_jvm\_memory\_pressure\_threshold) | Maximum percentage of Java heap used for data nodes before alarming | `number` | `80` | no |
+| <a name="input_master_cpu_utilization_threshold"></a> [master\_cpu\_utilization\_threshold](#input\_master\_cpu\_utilization\_threshold) | Maximum percentage of CPU utilization for master nodes before alarming | `number` | `80` | no |
+| <a name="input_master_jvm_memory_pressure_threshold"></a> [master\_jvm\_memory\_pressure\_threshold](#input\_master\_jvm\_memory\_pressure\_threshold) | Maximum percentage of Java heap used for master nodes before alarming | `number` | `80` | no |
+| <a name="input_free_storage_space_threshold"></a> [free\_storage\_space\_threshold](#input\_free\_storage\_space\_threshold) | Minimum free storage space per node in MiB before alarming | `number` | `20480` | no |
+| <a name="input_free_storage_space_total_threshold"></a> [free\_storage\_space\_total\_threshold](#input\_free\_storage\_space\_total\_threshold) | Minimum total free storage space across the cluster in MiB before alarming | `number` | `20480` | no |
+| <a name="input_min_available_nodes"></a> [min\_available\_nodes](#input\_min\_available\_nodes) | Minimum reachable nodes; set to non-zero to enable the node count alarm | `number` | `0` | no |
+| <a name="input_available_shards_threshold"></a> [available\_shards\_threshold](#input\_available\_shards\_threshold) | Maximum allocated shards before alarming; default tuned for a 6-node cluster at 90% of the 6000-shard limit | `number` | `5400` | no |
+| <a name="input_max_available_shards"></a> [max\_available\_shards](#input\_max\_available\_shards) | Maximum available shards per cluster; set to non-zero to enable the upper-bound check | `number` | `0` | no |
+| <a name="input_alarm_cluster_status_is_red_period"></a> [alarm\_cluster\_status\_is\_red\_period](#input\_alarm\_cluster\_status\_is\_red\_period) | Period in seconds for cluster status red alarm | `number` | `60` | no |
+| <a name="input_alarm_cluster_status_is_red_periods"></a> [alarm\_cluster\_status\_is\_red\_periods](#input\_alarm\_cluster\_status\_is\_red\_periods) | Number of consecutive periods before triggering cluster status red alarm | `number` | `1` | no |
+| <a name="input_alarm_cluster_status_is_yellow_period"></a> [alarm\_cluster\_status\_is\_yellow\_period](#input\_alarm\_cluster\_status\_is\_yellow\_period) | Period in seconds for cluster status yellow alarm | `number` | `60` | no |
+| <a name="input_alarm_cluster_status_is_yellow_periods"></a> [alarm\_cluster\_status\_is\_yellow\_periods](#input\_alarm\_cluster\_status\_is\_yellow\_periods) | Number of consecutive periods before triggering cluster status yellow alarm | `number` | `1` | no |
+| <a name="input_alarm_free_storage_space_too_low_period"></a> [alarm\_free\_storage\_space\_too\_low\_period](#input\_alarm\_free\_storage\_space\_too\_low\_period) | Period in seconds for per-node free storage alarm | `number` | `60` | no |
+| <a name="input_alarm_free_storage_space_too_low_periods"></a> [alarm\_free\_storage\_space\_too\_low\_periods](#input\_alarm\_free\_storage\_space\_too\_low\_periods) | Number of consecutive periods before triggering per-node free storage alarm | `number` | `1` | no |
+| <a name="input_alarm_free_storage_space_total_too_low_period"></a> [alarm\_free\_storage\_space\_total\_too\_low\_period](#input\_alarm\_free\_storage\_space\_total\_too\_low\_period) | Period in seconds for total cluster free storage alarm | `number` | `60` | no |
+| <a name="input_alarm_free_storage_space_total_too_low_periods"></a> [alarm\_free\_storage\_space\_total\_too\_low\_periods](#input\_alarm\_free\_storage\_space\_total\_too\_low\_periods) | Number of consecutive periods before triggering total cluster free storage alarm | `number` | `1` | no |
+| <a name="input_alarm_cluster_index_writes_blocked_period"></a> [alarm\_cluster\_index\_writes\_blocked\_period](#input\_alarm\_cluster\_index\_writes\_blocked\_period) | Period in seconds for writes blocked alarm | `number` | `300` | no |
+| <a name="input_alarm_cluster_index_writes_blocked_periods"></a> [alarm\_cluster\_index\_writes\_blocked\_periods](#input\_alarm\_cluster\_index\_writes\_blocked\_periods) | Number of consecutive periods before triggering writes blocked alarm | `number` | `1` | no |
+| <a name="input_alarm_min_available_nodes_period"></a> [alarm\_min\_available\_nodes\_period](#input\_alarm\_min\_available\_nodes\_period) | Period in seconds for minimum available nodes alarm | `number` | `86400` | no |
+| <a name="input_alarm_min_available_nodes_periods"></a> [alarm\_min\_available\_nodes\_periods](#input\_alarm\_min\_available\_nodes\_periods) | Number of consecutive periods before triggering minimum available nodes alarm | `number` | `1` | no |
+| <a name="input_alarm_automated_snapshot_failure_period"></a> [alarm\_automated\_snapshot\_failure\_period](#input\_alarm\_automated\_snapshot\_failure\_period) | Period in seconds for automated snapshot failure alarm | `number` | `60` | no |
+| <a name="input_alarm_automated_snapshot_failure_periods"></a> [alarm\_automated\_snapshot\_failure\_periods](#input\_alarm\_automated\_snapshot\_failure\_periods) | Number of consecutive periods before triggering snapshot failure alarm | `number` | `1` | no |
+| <a name="input_alarm_cpu_utilization_too_high_period"></a> [alarm\_cpu\_utilization\_too\_high\_period](#input\_alarm\_cpu\_utilization\_too\_high\_period) | Period in seconds for CPU utilization alarm | `number` | `900` | no |
+| <a name="input_alarm_cpu_utilization_too_high_periods"></a> [alarm\_cpu\_utilization\_too\_high\_periods](#input\_alarm\_cpu\_utilization\_too\_high\_periods) | Number of consecutive periods before triggering CPU utilization alarm | `number` | `3` | no |
+| <a name="input_alarm_jvm_memory_pressure_too_high_period"></a> [alarm\_jvm\_memory\_pressure\_too\_high\_period](#input\_alarm\_jvm\_memory\_pressure\_too\_high\_period) | Period in seconds for JVM memory pressure alarm | `number` | `900` | no |
+| <a name="input_alarm_jvm_memory_pressure_too_high_periods"></a> [alarm\_jvm\_memory\_pressure\_too\_high\_periods](#input\_alarm\_jvm\_memory\_pressure\_too\_high\_periods) | Number of consecutive periods before triggering JVM memory pressure alarm | `number` | `1` | no |
+| <a name="input_alarm_kms_period"></a> [alarm\_kms\_period](#input\_alarm\_kms\_period) | Period in seconds for KMS alarms | `number` | `60` | no |
+| <a name="input_alarm_kms_periods"></a> [alarm\_kms\_periods](#input\_alarm\_kms\_periods) | Number of consecutive periods before triggering KMS alarms | `number` | `1` | no |
+| <a name="input_alarm_master_cpu_utilization_too_high_period"></a> [alarm\_master\_cpu\_utilization\_too\_high\_period](#input\_alarm\_master\_cpu\_utilization\_too\_high\_period) | Period in seconds for master node CPU utilization alarm | `number` | `900` | no |
+| <a name="input_alarm_master_cpu_utilization_too_high_periods"></a> [alarm\_master\_cpu\_utilization\_too\_high\_periods](#input\_alarm\_master\_cpu\_utilization\_too\_high\_periods) | Number of consecutive periods before triggering master node CPU utilization alarm | `number` | `3` | no |
+| <a name="input_alarm_master_jvm_memory_pressure_too_high_period"></a> [alarm\_master\_jvm\_memory\_pressure\_too\_high\_period](#input\_alarm\_master\_jvm\_memory\_pressure\_too\_high\_period) | Period in seconds for master node JVM memory pressure alarm | `number` | `900` | no |
+| <a name="input_alarm_master_jvm_memory_pressure_too_high_periods"></a> [alarm\_master\_jvm\_memory\_pressure\_too\_high\_periods](#input\_alarm\_master\_jvm\_memory\_pressure\_too\_high\_periods) | Number of consecutive periods before triggering master node JVM memory pressure alarm | `number` | `1` | no |
+| <a name="input_alarm_allocated_shards_too_high_period"></a> [alarm\_allocated\_shards\_too\_high\_period](#input\_alarm\_allocated\_shards\_too\_high\_period) | Period in seconds for allocated shards alarm | `number` | `900` | no |
+| <a name="input_alarm_allocated_shards_too_high_periods"></a> [alarm\_allocated\_shards\_too\_high\_periods](#input\_alarm\_allocated\_shards\_too\_high\_periods) | Number of consecutive periods before triggering allocated shards alarm | `number` | `1` | no |
 
 ## Outputs
 
-|Name              | Description              |
-|------------------|--------------------------|
-| `sns_topic_arn`  | The ARN of the SNS topic |
-| `sns_topic_name` | The SNS topic name       |
+| Name | Description |
+|------|-------------|
+| <a name="output_sns_topic_arn"></a> [sns\_topic\_arn](#output\_sns\_topic\_arn) | The ARN of the SNS topic |
+| <a name="output_sns_topic_name"></a> [sns\_topic\_name](#output\_sns\_topic\_name) | The SNS topic name |
 
-## Share the Love
+## Resources
 
-Like this project? Please give it a ★ on [our GitHub](https://github.com/dubiety/terraform-aws-elasticsearch-cloudwatch-sns-alarms)!
-
-## Help
-
-**Got a question?**
-
-File a GitHub [issue](https://github.com/dubiety/terraform-aws-elasticsearch-cloudwatch-sns-alarms/issues).
-
-### Bug Reports & Feature Requests
-
-Please use the [issue tracker](https://github.com/dubiety/terraform-aws-elasticsearch-cloudwatch-sns-alarms/issues) to report any bugs or file feature requests.
-
-## License
-
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-
-See [LICENSE](LICENSE) for full details.
-
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
-
-      https://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_metric_alarm.allocated_shards_too_high](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.automated_snapshot_failure](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.cluster_index_writes_blocked](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.cluster_status_is_red](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.cluster_status_is_yellow](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.cpu_utilization_too_high](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.free_storage_space_too_low](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.free_storage_space_total_too_low](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.jvm_memory_pressure_too_high](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.kms_key_error](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.kms_key_inaccessible](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.master_cpu_utilization_too_high](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.master_jvm_memory_pressure_too_high](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.min_available_nodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_iam_policy_document.sns_topic_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_sns_topic.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic.default_prefix](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_policy) | resource |
+| [aws_caller_identity.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |


### PR DESCRIPTION
## Summary

- Rewrites `README.md` to follow the [Module README Template](https://elocal.atlassian.net/wiki/spaces/GP/pages/2951381008): adds Status (deprecated — Elasticsearch EOL, superseded by opensearch-alarms), Overview, Use this module instead of, What this module enforces, Usage examples, Configuration guide, What this module does not support, Version history, and full Requirements/Inputs/Outputs/Resources tables
- Adds `CLAUDE.md` per the proposed content in DEVOPS-3339
- Adds `.github/workflows/publish-docs.yml` to publish README to Confluence on tag push (uses centralized composite action)

## Test plan

- [x] Trigger "Publish README to Confluence" workflow via `workflow_dispatch` on this branch and verify the Confluence page is created/updated correctly
- [x] Verify all acceptance criteria in [DEVOPS-3339](https://elocal.atlassian.net/browse/DEVOPS-3339) are met

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEVOPS-3339]: https://elocal.atlassian.net/browse/DEVOPS-3339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ